### PR TITLE
Fixed changed siginception DNS::SEC name

### DIFF
--- a/dnssec_monitor.pm
+++ b/dnssec_monitor.pm
@@ -560,7 +560,7 @@ sub keyinfo {
 sub rrsig2time {
     my $rrsig = shift;
 
-    my $i = $rrsig->siginceptation;
+    my $i = $rrsig->siginception;
     my $e = $rrsig->sigexpiration;
 
     $i =~ s/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/$1:$2:$3 $4:$5:$6/;

--- a/nagios_zonecheck.pl
+++ b/nagios_zonecheck.pl
@@ -136,7 +136,7 @@ sub main {
 sub rrsig2time {
     my $rrsig = shift;
 
-    my $i = $rrsig->siginceptation;
+    my $i = $rrsig->siginception;
     my $e = $rrsig->sigexpiration;
 
     $i =~ s/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/$1:$2:$3 $4:$5:$6/;


### PR DESCRIPTION
According to http://www.net-dns.org/svn/net-dns-sec/trunk/Changes, `siginceptation` changed to `siginception` name in 0.12 (year 2005) and a deprecated name dropped in 0.21. Patch fixes a call.
